### PR TITLE
fix build with musl C library

### DIFF
--- a/src/core/spi.c
+++ b/src/core/spi.c
@@ -1,4 +1,5 @@
 #include <sys/ioctl.h>
+#include <linux/ioctl.h>
 #include <linux/spi/spidev.h>
 #include <fcntl.h>
 #include <errno.h>


### PR DESCRIPTION
With musl C library, we get following build error:

/home/buildroot/autobuild/run/instance-3/output/build/let-me-create-v1.5.2/src/core/spi.c: In function 'spi_transfer':
/home/buildroot/autobuild/run/instance-3/output/build/let-me-create-v1.5.2/src/core/spi.c:170:19: error: '_IOC_SIZEBITS' undeclared (first use in this function)
     if (ioctl(fd, SPI_IOC_MESSAGE(1), &tr) < 0) {
                   ^
/home/buildroot/autobuild/run/instance-3/output/build/let-me-create-v1.5.2/src/core/spi.c:170:19: note: each undeclared identifier is reported only once for each function it appears in

Include <linux/ioctl.h> for musl C library compatibility.

This build issue is detected by Buildroot autobuilder:
http://autobuild.buildroot.net/results/af9/af946fa6fe05ee265e4ac97742b15afeb0cea1ab/

Signed-off-by: Rahul Bedarkar <rahulbedarkar89@gmail.com>